### PR TITLE
fix for handling of empty iterables for __in args to filter

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 History
 -------
 
+0.1.2
+---------------------
+* [BUGFIX] - Properly handle passing of an empty iterable to '__in' filter args.  Related Django bug: https://code.djangoproject.com/ticket/12717
+
 0.1.1
 ---------------------
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ test_requirements = [
 
 setup(
     name='django-cache-manager',
-    version='0.1.1',
+    version='0.1.2',
     description='Cache manager for django models',
     long_description=readme + '\n\n' + history,
     author='Vijay Katam',

--- a/tests/cache_manager_tests.py
+++ b/tests/cache_manager_tests.py
@@ -4,6 +4,7 @@ import hashlib
 from unittest import TestCase
 from mock import patch, Mock
 
+from django.db.models.sql import EmptyResultSet
 
 from django_cache_manager.cache_manager import (
     CacheManager,
@@ -82,6 +83,12 @@ class CachingQuerySetTests(TestCase):
         self.query_set.update(name='name')
         self.assertEquals(invalidate_model_cache.call_count, 1)
 
-
-
-
+    def test_catch_empty_result_set(self, mock_generate_key, mock_cache_backend, invalidate_model_cache):
+        """
+        When an EmptyResultSet exception is raised in the process
+        of passing an empty iterable to an __in parameter, CacheManager
+        should correctly handle it and return None.
+        """
+        mock_generate_key.side_effect = EmptyResultSet()
+        manufacturers = Manufacturer.objects.filter(name__in=[])
+        self.assertEqual([], list(manufacturers))


### PR DESCRIPTION
Proposed fix for issue [#9](https://github.com/vijaykatam/django-cache-manager/issues/9)