### PR TITLE
fixing ascii encode error with hashlib.md5, adding testcase

### DIFF
--- a/django_cache_manager/mixins.py
+++ b/django_cache_manager/mixins.py
@@ -32,7 +32,7 @@ class CacheKeyMixin(object):
         query_key = u'{model_key}{qs}{db}'.format(model_key=key,
                                                   qs=sql,
                                                   db=self.db)
-        key = hashlib.md5(query_key).hexdigest()
+        key = hashlib.md5(query_key.encode('utf-8')).hexdigest()
         return key
 
     def sql(self):

--- a/tests/mixin_tests.py
+++ b/tests/mixin_tests.py
@@ -33,6 +33,17 @@ class CacheKeyMixinTests(TestCase):
         key2 = self.mixin.generate_key()
         self.assertEquals(key1, key2)
 
+    def test_key_generation_with_non_ascii_unicode(self, mock_sql, mock_model_cache):
+        """
+        When the query_key is unicode containing non-ascii characters, hashlib.md5 should not error out
+        """
+        mock_sql.return_value = u'\xf1'
+
+        try:
+            self.mixin.generate_key()
+        except UnicodeEncodeError:
+            self.fail("CacheKeyMixin.gernerate_key() raised a UnicodeEncodeError!")
+
     @patch('django_cache_manager.mixins.uuid')
     def test_new_key_generation(self, mock_uuid, mock_sql, mock_model_cache):
         """


### PR DESCRIPTION
Adding utf8 encoding to the query_key to resolve an issue I encountered when querying with a non-ascii character.