### PR TITLE
Use django.core.cache.caches as it stores off cache backend reference…

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 History
 -------
 
+0.2
+---------------------
+* Use django.core.cache.caches available in django 1.7 for efficient cache backend access
+
 0.1.5
 ---------------------
 * [BUGFIX] - Fix for non-ascii characters in query.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ test_requirements = [
 
 setup(
     name='django-cache-manager',
-    version='0.1.5',
+    version='0.2',
     description='Cache manager for django models',
     long_description=readme + '\n\n' + history,
     author='Vijay Katam',


### PR DESCRIPTION
Update mixins to use django caches API for retrieving cache backend when django version >= 1.7