### PR TITLE
Fix Django version in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ readme = open('README.md').read()
 history = open('HISTORY.md').read().replace('.. :changelog:', '')
 
 requirements = [
-    'Django<=1.9',
+    'Django<1.10',
 ]
 
 test_requirements = [


### PR DESCRIPTION
Current version of requirements in setup.py doesn't work well with `pip-compile` (https://github.com/nvie/pip-tools/). Concrete problem is discussed here: https://github.com/nvie/pip-tools/issues/323. This commit changes `<=1.9` to `<1.10`.