### PR TITLE
Fixed error: 'NoneType' object has no attribute '_meta'

### DIFF
--- a/django_cache_manager/models.py
+++ b/django_cache_manager/models.py
@@ -42,8 +42,9 @@ def invalidate_model_cache(sender, instance, **kwargs):
     if django.VERSION >= (1, 8):
         related_tables = set(
             [f.related_model._meta.db_table for f in sender._meta.get_fields()
-             if ((f.one_to_many or f.one_to_one) and f.auto_created)
-             or f.many_to_one or (f.many_to_many and not f.auto_created)])
+             if f.related_model is not None
+             and (((f.one_to_many or f.one_to_one) and f.auto_created)
+                 or f.many_to_one or (f.many_to_many and not f.auto_created))])
     else:
         related_tables = set([rel.model._meta.db_table for rel in sender._meta.get_all_related_objects()])
         # temporary fix for m2m relations with an intermediate model, goes away after better join caching


### PR DESCRIPTION
**Environment info:**
- Python 2.7.14
- Django-1.9.1
- django_cache_manager-0.5
- Windows 7 64 bit (also reproduced on Red Hat linux 6.4)

**Issue:**
When saving objects that contain an attribute of type [GenericForeignKey](https://docs.djangoproject.com/ko/1.11/ref/contrib/contenttypes/#django.contrib.contenttypes.fields.GenericForeignKey), an error is raised by django_cache_manager:

`AttributeError
'NoneType' object has no attribute '_meta' 
C:\Python27\venv\GVK\lib\site-packages\django_cache_manager\models.py in invalidate_model_cache, line 46`

The issue occurs because the GenericForeignKey has `related_model = None` causing the invalidate_model_cache function to break during `f.related_model._meta.db_table`

**Fix:**
I have fixed it for my project by adding the check `if f.related_model is not None`